### PR TITLE
Support configuring the archive compression level

### DIFF
--- a/src/main/java/ca/vanzyl/provisio/archive/Archiver.java
+++ b/src/main/java/ca/vanzyl/provisio/archive/Archiver.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
+import java.util.zip.Deflater;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.codehaus.plexus.util.SelectorUtils;
 
@@ -215,6 +216,7 @@ public class Archiver {
         boolean posixLongFileMode;
         List<String> hardLinkIncludes = new ArrayList<>();
         List<String> hardLinkExcludes = new ArrayList<>();
+        int compressionLevel = Deflater.DEFAULT_COMPRESSION;
 
         public ArchiverBuilder includes(String... includes) {
             return includes(Collections.unmodifiableList(new ArrayList<>(Arrays.asList(includes))));
@@ -288,6 +290,22 @@ public class Archiver {
 
         public ArchiverBuilder hardLinkExcludes(Iterable<String> hardLinkExcludes) {
             hardLinkExcludes.forEach(this.hardLinkExcludes::add);
+            return this;
+        }
+
+        /**
+         * Sets the compression level applied to the resulting archive.
+         *
+         * @param compressionLevel {@link Deflater#DEFAULT_COMPRESSION} to use the format's default, otherwise a value
+         *                         from 0 (no compression) to 9 (best compression). For zip and tar.gz this is the
+         *                         deflate/gzip level; for tar.xz it is the LZMA2 preset.
+         */
+        public ArchiverBuilder compressionLevel(int compressionLevel) {
+            if (compressionLevel != Deflater.DEFAULT_COMPRESSION && (compressionLevel < 0 || compressionLevel > 9)) {
+                throw new IllegalArgumentException("Invalid compression level " + compressionLevel + ": expected "
+                        + Deflater.DEFAULT_COMPRESSION + " for the default, or a value from 0 to 9.");
+            }
+            this.compressionLevel = compressionLevel;
             return this;
         }
 

--- a/src/main/java/ca/vanzyl/provisio/archive/ArchiverHelper.java
+++ b/src/main/java/ca/vanzyl/provisio/archive/ArchiverHelper.java
@@ -19,10 +19,14 @@ public class ArchiverHelper {
     public static ArchiveHandler getArchiveHandler(File archive, ArchiverBuilder builder) {
         ArchiveHandler archiveHandler;
         if (isZip(archive)) {
-            archiveHandler = new ZipArchiveHandler(archive);
+            archiveHandler = new ZipArchiveHandler(archive, builder.compressionLevel);
         } else if (isTarGz(archive)) {
             archiveHandler = new TarGzXzArchiveHandler(
-                    archive, builder.posixLongFileMode, builder.hardLinkIncludes, builder.hardLinkExcludes);
+                    archive,
+                    builder.posixLongFileMode,
+                    builder.hardLinkIncludes,
+                    builder.hardLinkExcludes,
+                    builder.compressionLevel);
         } else {
             throw new RuntimeException("Cannot detect how to read " + archive.getName());
         }

--- a/src/main/java/ca/vanzyl/provisio/archive/tar/TarGzXzArchiveHandler.java
+++ b/src/main/java/ca/vanzyl/provisio/archive/tar/TarGzXzArchiveHandler.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.zip.Deflater;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -26,6 +27,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarConstants;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipParameters;
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
 
@@ -35,11 +37,22 @@ public class TarGzXzArchiveHandler extends ArchiveHandlerSupport {
     private final boolean posixLongFileMode;
     private final Map<String, ExtendedArchiveEntry> processedFilesNames;
     private final Selector hardLinkSelector;
+    private final int compressionLevel;
 
     public TarGzXzArchiveHandler(
             File archive, boolean posixLongFileMode, List<String> hardLinkIncludes, List<String> hardLinkExcludes) {
+        this(archive, posixLongFileMode, hardLinkIncludes, hardLinkExcludes, Deflater.DEFAULT_COMPRESSION);
+    }
+
+    public TarGzXzArchiveHandler(
+            File archive,
+            boolean posixLongFileMode,
+            List<String> hardLinkIncludes,
+            List<String> hardLinkExcludes,
+            int compressionLevel) {
         this.archive = archive;
         this.posixLongFileMode = posixLongFileMode;
+        this.compressionLevel = compressionLevel;
         this.processedFilesNames = new TreeMap<>();
         if (!hardLinkIncludes.isEmpty() || !hardLinkExcludes.isEmpty()) {
             this.hardLinkSelector = new Selector(hardLinkIncludes, hardLinkExcludes);
@@ -82,9 +95,16 @@ public class TarGzXzArchiveHandler extends ArchiveHandlerSupport {
     public ArchiveOutputStream getOutputStream() throws IOException {
         TarArchiveOutputStream stream;
         if (archive.getName().endsWith(".xz")) {
-            stream = new TarArchiveOutputStream(new XZCompressorOutputStream(new FileOutputStream(archive)));
+            // XZ presets only accept 0-9, so fall back to the library default rather than passing -1 through.
+            stream = new TarArchiveOutputStream(
+                    compressionLevel == Deflater.DEFAULT_COMPRESSION
+                            ? new XZCompressorOutputStream(new FileOutputStream(archive))
+                            : new XZCompressorOutputStream(new FileOutputStream(archive), compressionLevel));
         } else {
-            stream = new TarArchiveOutputStream(new GzipCompressorOutputStream(new FileOutputStream(archive)));
+            GzipParameters parameters = new GzipParameters();
+            parameters.setCompressionLevel(compressionLevel);
+            stream = new TarArchiveOutputStream(
+                    new GzipCompressorOutputStream(new FileOutputStream(archive), parameters));
         }
         if (posixLongFileMode) {
             stream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);

--- a/src/main/java/ca/vanzyl/provisio/archive/zip/ZipArchiveHandler.java
+++ b/src/main/java/ca/vanzyl/provisio/archive/zip/ZipArchiveHandler.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.zip.Deflater;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
@@ -22,9 +23,15 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 public class ZipArchiveHandler extends ArchiveHandlerSupport {
 
     private final File archive;
+    private final int compressionLevel;
 
     public ZipArchiveHandler(File archive) {
+        this(archive, Deflater.DEFAULT_COMPRESSION);
+    }
+
+    public ZipArchiveHandler(File archive, int compressionLevel) {
         this.archive = archive;
+        this.compressionLevel = compressionLevel;
     }
 
     @Override
@@ -44,6 +51,8 @@ public class ZipArchiveHandler extends ArchiveHandlerSupport {
 
     @Override
     public ArchiveOutputStream getOutputStream() throws IOException {
-        return new ZipArchiveOutputStream(new FileOutputStream(archive));
+        ZipArchiveOutputStream stream = new ZipArchiveOutputStream(new FileOutputStream(archive));
+        stream.setLevel(compressionLevel);
+        return stream;
     }
 }

--- a/src/test/java/ca/vanzyl/provisio/archive/ArchiveTypeTest.java
+++ b/src/test/java/ca/vanzyl/provisio/archive/ArchiveTypeTest.java
@@ -1,6 +1,8 @@
 package ca.vanzyl.provisio.archive;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import ca.vanzyl.provisio.archive.source.FileSource;
 import java.io.File;
@@ -8,8 +10,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.util.List;
+import java.util.Random;
 import org.codehaus.plexus.util.Os;
 import org.codehaus.swizzle.stream.ReplaceStringInputStream;
 import org.junit.Assume;
@@ -431,6 +436,58 @@ public abstract class ArchiveTypeTest {
         validator.assertContentOfEntryInArchive(
                 "one/two/three/four/five/six/seven/eight/nine/ten/eleven/twelve/thirteen/fourteen/fifteen/sixteen/seventeen/entry.txt",
                 "entry.txt");
+    }
+
+    @Test
+    public void createArchiveWithCompressionLevel() throws Exception {
+        File content = compressibleFile();
+
+        File fastest = FileSystemAssert.getTargetArchive("compression-level-0." + getArchiveExtension());
+        Archiver.builder().compressionLevel(0).build().archive(fastest, new FileSource("content.txt", content));
+
+        File best = FileSystemAssert.getTargetArchive("compression-level-9." + getArchiveExtension());
+        Archiver.builder().compressionLevel(9).build().archive(best, new FileSource("content.txt", content));
+
+        assertTrue(
+                "Expected level 9 to produce a smaller archive than level 0, but got " + best.length() + " >= "
+                        + fastest.length(),
+                best.length() < fastest.length());
+
+        // The level must not affect what comes back out.
+        validator(best).assertEntries("content.txt");
+        validator(fastest).assertEntries("content.txt");
+    }
+
+    @Test
+    public void compressionLevelRejectsOutOfRangeValues() {
+        for (int level : new int[] {-2, 10}) {
+            try {
+                Archiver.builder().compressionLevel(level);
+                fail("Expected compression level " + level + " to be rejected.");
+            } catch (IllegalArgumentException expected) {
+                // expected
+            }
+        }
+    }
+
+    /**
+     * Writes a file that is compressible enough for the difference between compression levels to be measurable in
+     * every archive format under test, including xz where even the lowest preset compresses well.
+     */
+    private File compressibleFile() throws IOException {
+        File file = new File("target/compressible-content.txt");
+        file.getParentFile().mkdirs();
+        StringBuilder sb = new StringBuilder();
+        Random random = new Random(0);
+        for (int i = 0; i < 20000; i++) {
+            sb.append("entry-")
+                    .append(i)
+                    .append('-')
+                    .append(random.nextInt(1000))
+                    .append('\n');
+        }
+        Files.write(file.toPath(), sb.toString().getBytes(StandardCharsets.UTF_8));
+        return file;
     }
 
     public static String sha1(File file) throws Exception {


### PR DESCRIPTION
Adds a way to control how hard the archiver compresses, which currently is not configurable at all — every format is written at its library default.

## API

```java
Archiver.builder().compressionLevel(9).build()
```

Accepts `Deflater.DEFAULT_COMPRESSION` (-1, the default, preserving today's behavior) or a value from 0 to 9. Out-of-range values are rejected in the builder.

## Per-format wiring

| Format | Mechanism |
|---|---|
| zip | `ZipArchiveOutputStream.setLevel()` |
| tar.gz | `GzipParameters.setCompressionLevel()` |
| tar.xz | LZMA2 preset |

One wrinkle worth flagging for review: zip and gzip both accept `-1` as "use the library default", but XZ presets only accept 0–9. So for xz the default sentinel routes to the no-arg constructor rather than being passed through, which would otherwise throw. There's a comment at that call site.

## Compatibility

`ZipArchiveHandler` and `TarGzXzArchiveHandler` keep their existing constructor signatures as delegating overloads, so this is source- and binary-compatible for direct constructor users. Default behavior is unchanged.

## Tests

`createArchiveWithCompressionLevel` went into the shared `ArchiveTypeTest` base class, so it covers all three formats (21 tests each, 69 total, all green).

The test asserts level 9 produces a strictly smaller archive than level 0. I mutation-checked it by reverting the plumbing in `ArchiverHelper` and confirming it fails, rather than trusting a green run:

```
TarGzArchiverTypeTest  84460 >= 84460
ZipArchiverTypeTest    84465 >= 84465
TarXzArchiverTypeTest  42616 >= 42616
```

Byte-identical at both levels without the change — which is exactly what a silently-ignored parameter would look like.

## Motivation

Downstream, `provisio`'s `<archive>` action wants to expose a `compressionLevel` attribute, which isn't possible until the archiver supports it.